### PR TITLE
Change Grgit.open call to use currentDir instead of dir

### DIFF
--- a/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
@@ -43,26 +43,8 @@ class WPILibVersioningPlugin implements Plugin<Project> {
     // ^v(?<version>[0-9]+\.[0-9]+\.[0-9]+)(-(?<qualifier>(beta|rc)-[0-9]+))?(-(?<commits>[0-9]+)-(?<sha>g[a-f0-9]+))?$
     static final Pattern versionRegex = ~"^$mainVersionRegex($qualifierRegex)?($commitsRegex)?\$"
 
-    private File getGitDir(File currentDir) {
-        if (new File(currentDir, '.git').exists())
-            return currentDir
-
-        if (currentDir.parentFile == null)
-            return null
-
-        return getGitDir(currentDir.parentFile)
-    }
-
     private String getVersion(WPILibVersioningPluginExtension extension, Project project) {
-        // Determine the version number and make it available on our plugin extension
-        def gitDir = getGitDir(project.rootProject.rootDir)
-        // If no git directory was found, print a message to the console and return an empty string
-        if (gitDir == null) {
-            println "No .git was found in $project.rootProject.rootDir, or any parent directories of that directory."
-            println "No version number generated."
-            return ''
-        }
-        def git = Grgit.open(dir: gitDir.absolutePath)
+        def git = Grgit.open(currentDir: project.rootProject.rootDir)
         String tag = git.describe()
         boolean isDirty = !git.status().isClean()
         def match = tag =~ versionRegex

--- a/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
@@ -43,8 +43,26 @@ class WPILibVersioningPlugin implements Plugin<Project> {
     // ^v(?<version>[0-9]+\.[0-9]+\.[0-9]+)(-(?<qualifier>(beta|rc)-[0-9]+))?(-(?<commits>[0-9]+)-(?<sha>g[a-f0-9]+))?$
     static final Pattern versionRegex = ~"^$mainVersionRegex($qualifierRegex)?($commitsRegex)?\$"
 
+    private File getGitDir(File currentDir) {
+        if (new File(currentDir, '.git').exists())
+            return currentDir
+
+        if (currentDir.parentFile == null)
+            return null
+
+        return getGitDir(currentDir.parentFile)
+    }
+
     private String getVersion(WPILibVersioningPluginExtension extension, Project project) {
-        def git = Grgit.open(currentDir: project.rootProject.rootDir)
+        // Determine the version number and make it available on our plugin extension
+        def gitDir = getGitDir(project.rootProject.rootDir)
+        // If no git directory was found, print a message to the console and return an empty string
+        if (gitDir == null) {
+            println "No .git was found in $project.rootProject.rootDir, or any parent directories of that directory."
+            println "No version number generated."
+            return ''
+        }
+        def git = Grgit.open(currentDir: gitDir.absolutePath)
         String tag = git.describe()
         boolean isDirty = !git.status().isClean()
         def match = tag =~ versionRegex


### PR DESCRIPTION
This PR resolves #2, thus allowing projects such as WPILib to be built and used as Git Submodules in other projects.

This has been tested on my local machine and passed everything without a problem, and also appears to be working on the official allwpilib repository in both submodule and clone form. 