### PR TITLE
Change local build addition of "424242" to minor version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ publishing {
     }
 }
 
-version = '1.6'
+version = '2.0'
 group = 'edu.wpi.first.wpilib.versioning'
 
 pluginBundle {

--- a/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
@@ -21,9 +21,10 @@ class WPILibVersioningPlugin implements Plugin<Project> {
     // the final regex together
 
     // This is the only required part of the version. This captures a 'v', then 3 numbers separated by '.'.
-    // This introduces a capturing group for the main version number called 'version'.
-    static final String mainVersion = 'version'
-    private static final String mainVersionRegex = "v(?<$mainVersion>[0-9]+\\.[0-9]+\\.[0-9]+)"
+    // This introduces a capturing group for the major version number called 'major' and the remainder called 'minor'.
+    static final String majorVersion = 'major'
+    static final String minorVersion = 'minor'
+    private static final String mainVersionRegex = "v(?<$majorVersion>[0-9]+)(?<$minorVersion>\\.[0-9]+\\.[0-9]+)"
 
     // This is the alpha/beta/rc qualifier. It is a '-', followed by 'alpha', 'beta', or 'rc', followed by another '-', finally
     // followed by the alpha/beta/rc number. This introduces a capturing group for the qualifier number, called 'qualifier'.
@@ -73,13 +74,16 @@ class WPILibVersioningPlugin implements Plugin<Project> {
         }
 
         def versionBuilder = new StringBuilder()
-        // If this is a local build, we'll prepend 424242 to the version. This means that locally built versions will
+
+        versionBuilder.append(match.group(majorVersion))
+
+        // If this is a local build, we'll prepend 424242 to the minor version. This means that locally built versions will
         // always resolve first in the tree
         if (!project.hasProperty('jenkinsBuild')) {
-            versionBuilder.append('424242.')
+            versionBuilder.append('.424242')
         }
 
-        versionBuilder.append(match.group(mainVersion))
+        versionBuilder.append(match.group(minorVersion))
 
         if (match.group(qualifier) != null) {
             versionBuilder.append('-').append(match.group(qualifier))

--- a/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
+++ b/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
@@ -47,14 +47,14 @@ class WPILibVersioningPluginTests {
 
     @Test
     public void 'Version Regex Works'() {
-        verifyRegex('1.0.0')
-        verifyRegex('1.0.0', 'beta-1')
-        verifyRegex('1.0.0', 'rc-1')
-        verifyRegex('1.0.0', null, 1, 'g01235647')
-        verifyRegex('1.0.0', 'beta-1', 0, null)
-        verifyRegex('1.0.0', 'rc-1', 0, null)
-        verifyRegex('1.0.0', 'beta-1', 1, 'g01235647')
-        verifyRegex('1.0.0', 'rc-1', 1, 'g01235647')
+        verifyRegex('1', '.0.0')
+        verifyRegex('1', '.0.0', 'beta-1')
+        verifyRegex('1', '.0.0', 'rc-1')
+        verifyRegex('1', '.0.0', null, 1, 'g01235647')
+        verifyRegex('1', '.0.0', 'beta-1', 0, null)
+        verifyRegex('1', '.0.0', 'rc-1', 0, null)
+        verifyRegex('1', '.0.0', 'beta-1', 1, 'g01235647')
+        verifyRegex('1', '.0.0', 'rc-1', 1, 'g01235647')
     }
 
     @Test
@@ -133,14 +133,14 @@ class WPILibVersioningPluginTests {
     }
 
     @Test
-    public void 'Retrieves Correct Version: 424242.1.0.0 dev localBuild'() {
-        verifyProjectVersion('v1.0.0-rc-1', '20160803132333', ReleaseType.DEV, '424242.1.0.0-rc-1-20160803132333',
+    public void 'Retrieves Correct Version: 1.424242.0.0 dev localBuild'() {
+        verifyProjectVersion('v1.0.0-rc-1', '20160803132333', ReleaseType.DEV, '1.424242.0.0-rc-1-20160803132333',
                 null, true)
     }
 
-    static def verifyRegex(String mainVersion, String qualifier = null, int numCommits = 0, String hash = null) {
+    static def verifyRegex(String majorVersion, String minorVersion, String qualifier = null, int numCommits = 0, String hash = null) {
         def strBuilder = new StringBuilder()
-        strBuilder.append('v').append(mainVersion)
+        strBuilder.append('v').append(majorVersion).append(minorVersion)
 
         if (qualifier != null) {
             strBuilder.append("-$qualifier")
@@ -152,7 +152,8 @@ class WPILibVersioningPluginTests {
 
         def match = strBuilder.toString() =~ WPILibVersioningPlugin.versionRegex
         assertTrue(match.matches())
-        assertEquals(mainVersion, match.group(WPILibVersioningPlugin.mainVersion))
+        assertEquals(majorVersion, match.group(WPILibVersioningPlugin.majorVersion))
+        assertEquals(minorVersion, match.group(WPILibVersioningPlugin.minorVersion))
         assertEquals(qualifier, match.group(WPILibVersioningPlugin.qualifier))
         assertEquals(numCommits == 0 ? null : "$numCommits".toString(), match.group(WPILibVersioningPlugin.commits))
         assertEquals(hash, match.group(WPILibVersioningPlugin.sha))


### PR DESCRIPTION
This allows more natural use of semver for dependencies when mixed with
local builds, enabling dependencies to use "major.+" rather than just "+":
 Remote new major > Local prev major > Remote prev major
e.g.:
 3.0.0 > 2.424242.x.x > 2.x.x