### PR TITLE
Remove timestamp from jenkins build

### DIFF
--- a/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
@@ -97,7 +97,11 @@ class WPILibVersioningPlugin implements Plugin<Project> {
         if (extension.releaseType == ReleaseType.OFFICIAL)
             return versionBuilder.toString()
 
-        versionBuilder.append('-').append(extension.time)
+        // For jenkins builds, do not append the date
+        // This simplifies jenkins publishing because multiple commit builds can't happen.
+        if (!project.hasProperty('jenkinsBuild')) {
+            versionBuilder.append('-').append(extension.time)
+        }
 
         if (match.group(commits) != null && match.group(sha) != null)
             versionBuilder.append('-').append(match.group(commits))

--- a/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
+++ b/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
@@ -59,48 +59,48 @@ class WPILibVersioningPluginTests {
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0 official'() {
-        verifyProjectVersion('v1.0.0', '20160803132333', ReleaseType.OFFICIAL, "1.0.0")
+        verifyProjectVersion('v1.0.0', null, ReleaseType.OFFICIAL, "1.0.0")
     }
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0 dev'() {
-        verifyProjectVersion('v1.0.0', '20160803132333', ReleaseType.DEV, '1.0.0-20160803132333')
+        verifyProjectVersion('v1.0.0', null, ReleaseType.DEV, '1.0.0')
     }
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0-alpha-1 official'() {
-        verifyProjectVersion('v1.0.0-alpha-1', '20160803132333', ReleaseType.OFFICIAL, "1.0.0-alpha-1")
+        verifyProjectVersion('v1.0.0-alpha-1', null, ReleaseType.OFFICIAL, "1.0.0-alpha-1")
     }
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0-alpha-1 dev'() {
-        verifyProjectVersion('v1.0.0-alpha-1', '20160803132333', ReleaseType.DEV, "1.0.0-alpha-1-20160803132333")
+        verifyProjectVersion('v1.0.0-alpha-1', null, ReleaseType.DEV, "1.0.0-alpha-1")
     }
 
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0-beta-1 official'() {
-        verifyProjectVersion('v1.0.0-beta-1', '20160803132333', ReleaseType.OFFICIAL, "1.0.0-beta-1")
+        verifyProjectVersion('v1.0.0-beta-1', null, ReleaseType.OFFICIAL, "1.0.0-beta-1")
     }
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0-beta-1 dev'() {
-        verifyProjectVersion('v1.0.0-beta-1', '20160803132333', ReleaseType.DEV, "1.0.0-beta-1-20160803132333")
+        verifyProjectVersion('v1.0.0-beta-1', null, ReleaseType.DEV, "1.0.0-beta-1")
     }
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0-rc-1 official'() {
-        verifyProjectVersion('v1.0.0-rc-1', '20160803132333', ReleaseType.OFFICIAL, "1.0.0-rc-1")
+        verifyProjectVersion('v1.0.0-rc-1', null, ReleaseType.OFFICIAL, "1.0.0-rc-1")
     }
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0-rc-1 dev'() {
-        verifyProjectVersion('v1.0.0-rc-1', '20160803132333', ReleaseType.DEV, "1.0.0-rc-1-20160803132333")
+        verifyProjectVersion('v1.0.0-rc-1', null, ReleaseType.DEV, "1.0.0-rc-1")
     }
 
     @Test
     public void 'Retrieves Correct Version: 1.0.0 dev dirty'() {
-        verifyProjectVersion('v1.0.0', '20160803132333', ReleaseType.DEV, "1.0.0-20160803132333-dirty",
+        verifyProjectVersion('v1.0.0', null, ReleaseType.DEV, "1.0.0-dirty",
                 { project, git ->
                     new File(project.rootDir, "temp").createNewFile()
                 })
@@ -109,7 +109,7 @@ class WPILibVersioningPluginTests {
     @Test
     public void 'Retrieves Correct Version: 1.0.0 dev commits'() {
         def ogit
-        verifyProjectVersion('v1.0.0', '20160803132333', ReleaseType.DEV, "1.0.0-20160803132333-1-g${-> ogit.log().get(0).getAbbreviatedId()}",
+        verifyProjectVersion('v1.0.0', null, ReleaseType.DEV, "1.0.0-1-g${-> ogit.log().get(0).getAbbreviatedId()}",
                 { project, git ->
                     ogit = git
                     new File(project.rootDir, "temp").createNewFile()
@@ -121,7 +121,7 @@ class WPILibVersioningPluginTests {
     @Test
     public void 'Retrieves Correct Version: 1.0.0 dev commits dirty'() {
         def ogit
-        verifyProjectVersion('v1.0.0', '20160803132333', ReleaseType.DEV, "1.0.0-20160803132333-1-g${->ogit.log().get(0).getAbbreviatedId()}-dirty",
+        verifyProjectVersion('v1.0.0', null, ReleaseType.DEV, "1.0.0-1-g${->ogit.log().get(0).getAbbreviatedId()}-dirty",
                 { project, git ->
                     ogit = git
                     new File(project.rootDir, "temp").createNewFile()
@@ -208,11 +208,13 @@ class WPILibVersioningPluginTests {
         def git = tuple.first
         def project = tuple.second
 
-        if (!isLocalBuild)
+        if (!isLocalBuild) {
             project.ext.jenkinsBuild = false
+        } else {
+            project.extensions.getByName('WPILibVersion').time = time
+        }
 
         git.tag.add(name: gitTag, annotate: true)
-        project.extensions.getByName('WPILibVersion').time = time
 
         // Call the afterTag closure if it's not null. This allows tests to modify the output by adding things to the
         // project, creating new commits, etc.


### PR DESCRIPTION
Per slack discussion, the date timestamp is not super helpful when built with jenkins, and because of changes necessary for Java 11, tools were going to have issues with this functionality. Local builds still have the timestamp, and jenkins builds are still stable and increasing because describe still have a commit count since last tag.