### PR TITLE
Support a null tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
     jcenter()
 }
 
-version = '2.4'
+version = '2.5'
 group = 'edu.wpi.first.wpilib.versioning'
 
 pluginBundle {

--- a/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPlugin.groovy
@@ -79,13 +79,15 @@ class WPILibVersioningPlugin implements Plugin<Project> {
 
         Tag describeTag = null
 
-        // Find tag hash that starts with describe
-        tags.find { Tag tg ->
-            if (tag.startsWith(tg.name)) {
-                describeTag = tg
-                return true
+        if (tag != null && tags != null) {
+            // Find tag hash that starts with describe
+            tags.find { Tag tg ->
+                if (tag.startsWith(tg.name)) {
+                    describeTag = tg
+                    return true
+                }
+                return false
             }
-            return false
         }
 
         // If we found the tag matching describe


### PR DESCRIPTION
They happen if there is no current tag, which shouldn't throw an NPE.