### PR TITLE
Add GITHUB_REF detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
 dependencies {
     compile 'org.ajoberstar.grgit:grgit-core:3.0.0'
     testCompile 'junit:junit:4.12'
+    testCompile 'com.github.stefanbirkner:system-lambda:1.1.1'
 }
 
 repositories {

--- a/src/main/groovy/edu/wpi/first/wpilib/versioning/GitVersionProvider.groovy
+++ b/src/main/groovy/edu/wpi/first/wpilib/versioning/GitVersionProvider.groovy
@@ -51,56 +51,72 @@ class GitVersionProvider implements WPILibVersionProvider {
     }
 
     public String getVersion(WPILibVersioningPluginExtension extension, Project project, boolean allTags) {
-        // Determine the version number and make it available on our plugin extension
-        def gitDir = getGitDir(project.rootProject.rootDir)
-        // If no git directory was found, print a message to the console and return an empty string
-        if (gitDir == null) {
-            println "No .git was found in $project.rootProject.rootDir, or any parent directories of that directory."
-            println "No version number generated."
-            return ''
-        }
+        String tag = null
+        boolean isDirty = false;
 
-        Grgit git = Grgit.open(currentDir: (Object)gitDir.absolutePath)
-        // Get the tag given by describe
-        String tag = git.describe(tags: (Object)allTags)
+        // Check to see if we are running on CI
+        if (System.getenv("CI") == "true") {
+            def githubRef = System.getenv("GITHUB_REF")
+            if (extension.releaseMode && githubRef.startsWith("refs/tags/")) {
+                tag = githubRef.replace("refs/tags/", "")
 
-        // Get a list of all tags
-        List<Tag> tags = git.tag.list()
-
-        Tag describeTag = null
-
-        if (tag != null && tags != null) {
-            // Find tag hash that starts with describe
-            tags.find { Tag tg ->
-                if (tag.startsWith(tg.name)) {
-                    describeTag = tg
-                    return true
-                }
-                return false
+                println "GitHub provided a tag via the GITHUB_REF environment variable: $githubRef"
             }
         }
 
-        // If we found the tag matching describe
-        if (describeTag != null) {
-            String commitId = describeTag.commit.id
+        if (tag == null) {
+            // We are not on CI or CI failed to provide a tag, need to use git
+            // Determine the version number and make it available on our plugin extension
+            def gitDir = getGitDir(project.rootProject.rootDir)
+            // If no git directory was found, print a message to the console and return an empty string
+            if (gitDir == null) {
+                println "No .git was found in $project.rootProject.rootDir, or any parent directories of that directory."
+                println "No version number generated."
+                return ''
+            }
 
-            // Find all tags matching commit
-            // Sort by date
-            Tag newestTag = tags.findAll {
-                it.commit.id.equals(commitId)
-            }.sort {
-                it.dateTime
-            }.last()
+            Grgit git = Grgit.open(currentDir: (Object)gitDir.absolutePath)
+            // Get the tag given by describe
+            tag = git.describe(tags: (Object)allTags)
 
-            // Replace describe tag with newest
-            tag = tag.replace(describeTag.name, newestTag.name)
+            // Get a list of all tags
+            List<Tag> tags = git.tag.list()
+
+            Tag describeTag = null
+
+            if (tag != null && tags != null) {
+                // Find tag hash that starts with describe
+                tags.find { Tag tg ->
+                    if (tag.startsWith(tg.name)) {
+                        describeTag = tg
+                        return true
+                    }
+                    return false
+                }
+            }
+
+            // If we found the tag matching describe
+            if (describeTag != null) {
+                String commitId = describeTag.commit.id
+
+                // Find all tags matching commit
+                // Sort by date
+                Tag newestTag = tags.findAll {
+                    it.commit.id.equals(commitId)
+                }.sort {
+                    it.dateTime
+                }.last()
+
+                // Replace describe tag with newest
+                tag = tag.replace(describeTag.name, newestTag.name)
+            }
+
+            isDirty = !git.status().isClean()
         }
 
-        boolean isDirty = !git.status().isClean()
         def match = tag =~ versionRegex
         if (!match.matches()) {
-            String annotated = allTags ? "" : "annotated"
-            println "Latest $annotated tag is $tag. This does not match the expected version number pattern."
+            println "Tag is $tag. This does not match the expected version number pattern."
             println "No version number was generated."
             return ''
         }

--- a/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
+++ b/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
@@ -11,6 +11,7 @@ import java.nio.file.Files
 
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertTrue
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable
 
 /**
  * Tests for the wpilib versioning plugin
@@ -114,6 +115,13 @@ class WPILibVersioningPluginTests {
     public void 'Retrieves Correct Version 1_424242_0_0 dev localBuild'() {
         verifyProjectVersion('v1.0.0-rc-1', '20160803132333', false, '1.424242.0.0-rc-1-20160803132333',
                 null, true)
+    }
+
+    @Test
+    public void 'Uses GitHub provided tag instead of git'() {
+        withEnvironmentVariable("CI", "true")
+                .and("GITHUB_REF", "refs/tags/v1.0.0-beta-2")
+                .execute({ -> verifyProjectVersion('v1.0.0-beta-1', null, true, "1.0.0-beta-2") })
     }
 
     static def verifyRegex(String majorVersion, String minorVersion, String qualifier = null, int numCommits = 0, String hash = null) {


### PR DESCRIPTION
This is a workaround for https://github.com/actions/checkout/issues/290.  As described in that issue, the goal of the checkout action is to always run on the provided build hash even if additional tags have been pushed. This means if a user pushed 2 tags at the same time, 2 build artifacts will result. One workaround proposed is to force pull tags. This workaround breaks the promise of GitHub builds – 2 tag pushes now can result in 2 independent builds but 1 build artifact total.

This PR adds detection for the `GITHUB_REF` environment variable. If we detect the variable and are in release mode, we will trust that the variable is correct. Otherwise, we fallback onto the already proven git describe method.

You can see it in action here:

master: https://github.com/AustinShalit/OutlineViewer/runs/1616714453?check_suite_focus=true
"beta 5": https://github.com/AustinShalit/OutlineViewer/runs/1616715084?check_suite_focus=true
"beta 6": https://github.com/AustinShalit/OutlineViewer/runs/1616715071?check_suite_focus=true