### PR TITLE
adds optional 'match' flag to git describe

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
     }
 }
 
-version = '2023.0.1'
+version = '2024.0.0'
 group = 'edu.wpi.first.wpilib.versioning'
 
 pluginBundle {

--- a/src/main/java/edu/wpi/first/wpilib/versioning/GitVersionProvider.java
+++ b/src/main/java/edu/wpi/first/wpilib/versioning/GitVersionProvider.java
@@ -65,7 +65,7 @@ public class GitVersionProvider implements WPILibVersionProvider {
         return getGitDir(currentDir.getParentFile());
     }
 
-    public String getVersion(WPILibVersioningPluginExtension extension, Project project, boolean allTags) {
+    public String getVersion(WPILibVersioningPluginExtension extension, Project project, boolean allTags, List<String> matchGlobs) {
         String tag = null;
         boolean isDirty = false;
 
@@ -93,7 +93,7 @@ public class GitVersionProvider implements WPILibVersionProvider {
             }
 
             Map<String, Object> openArgs = Map.of("currentDir", (Object)gitDir.getAbsolutePath());
-            Map<String, Object> describeArgs = Map.of("tags", (Object)allTags);
+            Map<String, Object> describeArgs = Map.of("tags", (Object)allTags, "match", (Object)matchGlobs);
 
             Grgit git = Grgit.open(openArgs);
             // Get the tag given by describe

--- a/src/main/java/edu/wpi/first/wpilib/versioning/WPILibVersionProvider.java
+++ b/src/main/java/edu/wpi/first/wpilib/versioning/WPILibVersionProvider.java
@@ -1,9 +1,11 @@
 package edu.wpi.first.wpilib.versioning;
 
+import java.util.List;
+
 import org.gradle.api.Project;
 
 // Interface to make passing a groovy function to a java API possible
 // without completely loosing intellisense.
 public interface WPILibVersionProvider {
-    String getVersion(WPILibVersioningPluginExtension extension, Project project, boolean allTags);
+    String getVersion(WPILibVersioningPluginExtension extension, Project project, boolean allTags, List<String> matchGlobs);
 }

--- a/src/main/java/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginExtension.java
+++ b/src/main/java/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginExtension.java
@@ -2,6 +2,8 @@ package edu.wpi.first.wpilib.versioning;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.gradle.api.Project;
 import org.gradle.api.provider.Property;
@@ -14,6 +16,7 @@ public class WPILibVersioningPluginExtension {
     private boolean useAllTags = false;
     private boolean buildServerMode = false;
     private boolean releaseMode = false;
+    private List<String> matchGlobs = new ArrayList<>();
 
     public WPILibVersioningPluginExtension(Project project, WPILibVersionProvider versionProvider) {
         version = project.getObjects().property(String.class);
@@ -21,7 +24,7 @@ public class WPILibVersioningPluginExtension {
 
         LocalDateTime.now();
         time.set(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss")));
-        version.set(project.provider(() -> versionProvider.getVersion(this, project, this.useAllTags)));
+        version.set(project.provider(() -> versionProvider.getVersion(this, project, this.useAllTags, this.matchGlobs)));
     }
 
     public Property<String> getTime() {
@@ -54,5 +57,13 @@ public class WPILibVersioningPluginExtension {
 
     public void setUseAllTags(boolean allTags) {
         useAllTags = allTags;
+    }
+
+    public void setMatchGlobs(List<String> globList) {
+        matchGlobs = globList;
+    }
+
+    public void addMatchGlob(String glob) {
+        matchGlobs.add(glob);
     }
 }

--- a/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
+++ b/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
@@ -142,6 +142,30 @@ class WPILibVersioningPluginTests {
                 .execute({ -> verifyProjectVersion('v1.0.0-beta-1', null, true, "1.0.0-beta-2") })
     }
 
+    @Test
+    public void 'Retrieves empty if annotated tag does not match'() {
+        verifyProjectVersion('v1.0.0', null, true, "",
+                { project, git ->
+                    new File(project.rootDir, "temp").createNewFile()
+                    git.add(patterns: ['temp'])
+                    git.commit(message: 'second commit')
+                    git.tag.add(name: 'NewInvalidTag', annotate: true)
+                })
+    }
+
+    @Test
+    public void 'Retrieves Correct Version 1_0_0 when newest tag is invalid if matchGlob is set'() {
+        verifyProjectVersion('v1.0.0', null, true, "1.0.0",
+                { project, git ->
+                    new File(project.rootDir, "temp").createNewFile()
+                    git.add(patterns: ['temp'])
+                    git.commit(message: 'second commit')
+                    git.tag.add(name: 'NewInvalidTag', annotate: true)
+
+                    project.extensions.getByName('wpilibVersioning').addMatchGlob("[v]*[.]*[.]*")
+                })
+    }
+
     static def verifyRegex(String majorVersion, String minorVersion, String qualifier = null, int numCommits = 0, String hash = null) {
         def strBuilder = new StringBuilder()
         strBuilder.append('v').append(majorVersion).append(minorVersion)
@@ -206,6 +230,7 @@ class WPILibVersioningPluginTests {
 
 
         def version = project.extensions.getByName('wpilibVersioning').version.get()
+        println("Obtained Version: " + version)
         assertEquals(expectedVersion, version)
     }
 

--- a/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
+++ b/src/test/groovy/edu/wpi/first/wpilib/versioning/WPILibVersioningPluginTests.groovy
@@ -230,7 +230,6 @@ class WPILibVersioningPluginTests {
 
 
         def version = project.extensions.getByName('wpilibVersioning').version.get()
-        println("Obtained Version: " + version)
         assertEquals(expectedVersion, version)
     }
 


### PR DESCRIPTION
Adds the option to specify "match" wildcards for git describe.
Default behavior without match globs specified is unchanged and will still return an empty version if the latest annotated tag does not follow the implemented semver requirements.

Adding a match wildcard is useful during dev or local builds if there are other formats of annotated tags between the latest commit and the last valid version tag.

This does NOT change what version formats the plugin will process; the same valid tag format is still required.
