### PR TITLE
Handle invalid tags properly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ repositories {
     }
 }
 
-version = '2027.0.0'
+version = '2027.0.1'
 group = 'org.wpilib'
 
 gradlePlugin {

--- a/src/main/java/org/wpilib/versioning/GitTag.java
+++ b/src/main/java/org/wpilib/versioning/GitTag.java
@@ -21,24 +21,32 @@ public class GitTag {
 
     private final ZonedDateTime dateTime;
 
-    public GitTag(Git git, Ref ref) {
-        name = Repository.shortenRefName(ref.getName());
+    public static GitTag fromRef(Git git, Ref ref) {
+        String name = Repository.shortenRefName(ref.getName());
 
         try (RevWalk walk = new RevWalk(git.getRepository())) {
             RevTag rev = walk.parseTag(ref.getObjectId());
             RevObject target = walk.peel(rev);
             walk.parseBody(rev.getObject());
-            commitId = ObjectId.toString(target);
+            String commitId = ObjectId.toString(target);
 
             Instant instant = rev.getTaggerIdent().getWhenAsInstant();
             ZoneId zone = rev.getTaggerIdent().getZoneId();
             if (zone == null) {
                 zone = ZoneOffset.UTC;
             }
-            dateTime = ZonedDateTime.ofInstant(instant, zone);
+            ZonedDateTime dateTime = ZonedDateTime.ofInstant(instant, zone);
+            return new GitTag(name, commitId, dateTime);
         } catch (IOException e) {
-            throw new RuntimeException("Error reading git tag " + name, e);
+            return null;
         }
+    }
+
+    private GitTag(String name, String commitId, ZonedDateTime dateTime) {
+        this.name = name;
+        this.commitId = commitId;
+        this.dateTime = dateTime;
+
     }
 
     public String getName() {

--- a/src/main/java/org/wpilib/versioning/GitVersionProvider.java
+++ b/src/main/java/org/wpilib/versioning/GitVersionProvider.java
@@ -118,7 +118,7 @@ public class GitVersionProvider implements WPILibVersionProvider {
                 describe.setMatch(matchGlobs.toArray(String[]::new));
                 tag = describe.call();
 
-                List<GitTag> tags = git.tagList().call().stream().map(x -> new GitTag(git, x)).toList();
+                List<GitTag> tags = git.tagList().call().stream().map(x -> GitTag.fromRef(git, x)).filter(x -> x != null).toList();
 
                 GitTag describeTag = null;
 


### PR DESCRIPTION
The old functionality would never have thrown here, and instead just treated the tag as a normal commit, which isn't right for our purposes. Just make those be considered not tags